### PR TITLE
Fixing #1428: "unicode_internal" workaround (3.8+)

### DIFF
--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -6,6 +6,7 @@ from win32api import BeginUpdateResource, UpdateResource, EndUpdateResource
 import os
 import struct
 import glob
+import sys
 
 import optparse
 

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -47,7 +47,16 @@ def VS_FIXEDFILEINFO(maj, min, sub, build, debug=0, is_dll=1):
 
 def nullterm(s):
   # get raw bytes for a NULL terminated unicode string.
-  return (unicode(s) + u'\0').encode('unicode-internal')
+  if sys.version_info[:2] < (3, 8):
+    return (str(s) + '\0').encode('unicode-internal')
+  else:
+    bytes_ = b''
+    for c in str(s):
+      bytes_ += bytes(c, 'unicode_escape')
+      bytes_ += b'\x00'
+
+    bytes_ += b'\x00\x00'
+    return bytes_
 
 def pad32(s, extra=2):
   # extra is normally 2 to deal with wLength

--- a/win32/Lib/win32verstamp.py
+++ b/win32/Lib/win32verstamp.py
@@ -51,13 +51,7 @@ def nullterm(s):
   if sys.version_info[:2] < (3, 8):
     return (str(s) + '\0').encode('unicode-internal')
   else:
-    bytes_ = b''
-    for c in str(s):
-      bytes_ += bytes(c, 'unicode_escape')
-      bytes_ += b'\x00'
-
-    bytes_ += b'\x00\x00'
-    return bytes_
+    return (str(s) + '\0').encode('utf-16le')
 
 def pad32(s, extra=2):
   # extra is normally 2 to deal with wLength


### PR DESCRIPTION
Since "unicode_internal" codec was removed in Python 3.8, nullterm() method needs a workaround for this for Python 3.8+